### PR TITLE
WIP: Packer recipe - offline Terraform server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# terraform-offline-server-packer-reciepe
+# Offline Terraform server
+
 Packer recipe to build an offline Terraform server that uses a local to disk GCP Provider

--- a/config.pkr.hcl
+++ b/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 1.0.16"
+      source  = "github.com/hashicorp/googlecompute"
+    }
+  }
+}

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -22,7 +22,8 @@ build {
       "sudo adduser terra",
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",
-      "mkdir -p /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
+      "sudo mkdir -p /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
+      "sudo chown -R terra:terra /home/terra/",
       "sudo gsutil cp gs://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
     ]
   }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -1,0 +1,1 @@
+# Ensure an offline Terraform server using local GCP Provider files

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -21,6 +21,8 @@ build {
       "sudo dnf install git -y",
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",
+      "mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
+      "sudo gsutil cp gsp://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
     ]
   }
 }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -22,7 +22,7 @@ build {
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",
       "mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
-      "sudo gsutil cp gsp://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
+      "sudo gsutil cp gs://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
     ]
   }
 }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,7 +6,7 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline-v01"
+  image_name              = "terraform-offline-v02"
   image_description       = "Terraform server v.0.1"
   image_storage_locations = ["us-west1"]
 }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,8 +6,8 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline-v02"
-  image_description       = "Terraform server v.0.1"
+  image_name              = "terraform-offline-v03"
+  image_description       = "Terraform server v.0.3"
   image_storage_locations = ["us-west1"]
 }
 

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -1,1 +1,24 @@
 # Ensure an offline Terraform server using local GCP Provider files
+source "googlecompute" "terraform-offline" {
+  project_id              = "simplifymycloud-dev"
+  source_image_family     = "rocky-linux-8"
+  ssh_username            = "packer"
+  use_os_login            = true
+  zone                    = "us-west1-c"
+  subnetwork              = "smc-dev-subnet-01"
+  image_name              = "terraform-offline-v.0.1"
+  image_description       = "Debian 11 golden image v.0.1"
+  image_storage_locations = ["us-west1"]
+}
+
+build {
+  sources = ["sources.googlecompute.terraform-offline"]
+  provisioner "shell" {
+    inline = [
+      "sudo dnf update -y",
+      "sudo dnf install unzip -y",
+      "sudo dnf install wget -y",
+      "sudo dnf install git -y",
+    ]
+  }
+}

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -25,6 +25,7 @@ build {
       "sudo mkdir -p /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
       "sudo gsutil cp gs://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
       "sudo chown -R terra:terra /home/terra/",
+      "sudo chmod 0755 /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/terraform-provider-google_v4.46.0_x5",
     ]
   }
 }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,8 +6,8 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline-v.0.1"
-  image_description       = "Debian 11 golden image v.0.1"
+  image_name              = "terraform-offline"
+  image_description       = "Terraform server v.0.1"
   image_storage_locations = ["us-west1"]
 }
 

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,8 +6,8 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline-v04"
-  image_description       = "Terraform server v.0.4"
+  image_name              = "terraform-offline-v05"
+  image_description       = "Terraform server v.0.5"
   image_storage_locations = ["us-west1"]
 }
 

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -19,10 +19,11 @@ build {
       #"sudo dnf install unzip -y",
       #"sudo dnf install wget -y",
       #"sudo dnf install git -y",
+      "sudo adduser terra",
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",
-      "mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
-      "sudo gsutil cp gs://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
+      "mkdir -p /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
+      "sudo gsutil cp gs://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
     ]
   }
 }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,8 +6,8 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline-v05"
-  image_description       = "Terraform server v.0.5"
+  image_name              = "terraform-offline-v1"
+  image_description       = "Terraform server v.1.0"
   image_storage_locations = ["us-west1"]
 }
 

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -15,10 +15,10 @@ build {
   sources = ["sources.googlecompute.terraform-offline"]
   provisioner "shell" {
     inline = [
-      "sudo dnf update -y",
-      "sudo dnf install unzip -y",
-      "sudo dnf install wget -y",
-      "sudo dnf install git -y",
+      #"sudo dnf update -y",
+      #"sudo dnf install unzip -y",
+      #"sudo dnf install wget -y",
+      #"sudo dnf install git -y",
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",
       "mkdir -p ~/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,8 +6,8 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline-v03"
-  image_description       = "Terraform server v.0.3"
+  image_name              = "terraform-offline-v04"
+  image_description       = "Terraform server v.0.4"
   image_storage_locations = ["us-west1"]
 }
 

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -23,8 +23,8 @@ build {
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",
       "sudo mkdir -p /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64",
-      "sudo chown -R terra:terra /home/terra/",
       "sudo gsutil cp gs://smc-artifact-shelf/gcp-provider-terraform/terraform-provider-google_v4.46.0_x5 /home/terra/.terraform.d/plugins/registry.terraform.io/hashicorp/google/4.46.0/linux_amd64/.",
+      "sudo chown -R terra:terra /home/terra/",
     ]
   }
 }

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -15,10 +15,10 @@ build {
   sources = ["sources.googlecompute.terraform-offline"]
   provisioner "shell" {
     inline = [
-      #"sudo dnf update -y",
-      #"sudo dnf install unzip -y",
-      #"sudo dnf install wget -y",
-      #"sudo dnf install git -y",
+      "sudo dnf update -y",
+      "sudo dnf install unzip -y",
+      "sudo dnf install wget -y",
+      "sudo dnf install git -y",
       "sudo adduser terra",
       "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
       "sudo chmod 0755 /usr/local/bin/terraform",

--- a/terraform-offline.pkr.hcl
+++ b/terraform-offline.pkr.hcl
@@ -6,7 +6,7 @@ source "googlecompute" "terraform-offline" {
   use_os_login            = true
   zone                    = "us-west1-c"
   subnetwork              = "smc-dev-subnet-01"
-  image_name              = "terraform-offline"
+  image_name              = "terraform-offline-v01"
   image_description       = "Terraform server v.0.1"
   image_storage_locations = ["us-west1"]
 }
@@ -19,6 +19,8 @@ build {
       "sudo dnf install unzip -y",
       "sudo dnf install wget -y",
       "sudo dnf install git -y",
+      "sudo gsutil cp gs://smc-artifact-shelf/terraform/terraform /usr/local/bin/.",
+      "sudo chmod 0755 /usr/local/bin/terraform",
     ]
   }
 }


### PR DESCRIPTION
Ensure the Terraform server is baked via Packer and follows these requirements:

- [ ] Offline from the internet networking - local access only via `10.0.0.0`
- [ ] Does not require a NAT Gateway to function
- [ ] Contains all GCP Provider files local on disk
- [ ] Is versioned to the GCP Provider version number
- [ ] Has sane aliases